### PR TITLE
Add Archive section to Fora

### DIFF
--- a/fora.md
+++ b/fora.md
@@ -19,6 +19,7 @@ If you're running an urbit, to post as your ship, [_Log In_](/~~/).
   <a class="subfora" href="../updates">Updates</a>
   <a class="subfora" href="./answers">Answers</a>
   <a class="subfora" href="./proposals">Proposals</a>
+  <a class="subfora" href="../archive">Archive</a>
 </nav>
 
 Long-form Urbit discussion.

--- a/fora/answers.md
+++ b/fora/answers.md
@@ -19,6 +19,7 @@ If you're running an urbit, to post as your ship, [_Log In_](/~~/).
   <a class="subfora" href="../updates">Updates</a>
   <b class="subfora active">Answers</b>
   <a class="subfora" href="../proposals">Proposals</a>
+  <a class="subfora" href="../archive">Archive</a>
 </nav>
 
 Share your Urbit knowledge here, and ask questions.

--- a/fora/archive.md
+++ b/fora/archive.md
@@ -18,11 +18,11 @@ If you're running an urbit, to post as your ship, [_Log In_](/~~/).
   <a class="subfora" href="../general">General</a>
   <a class="subfora" href="../updates">Updates</a>
   <a class="subfora" href="../answers">Answers</a>
-  <b class="subfora active">Proposals</b>
-  <a class="subfora" href="../archive">Archive</a>
+  <a class="subfora" href="../proposals">Proposals</a>
+  <b class="subfora active">Archive</b>
 </nav>
 
-Urbit Proposals (UPs) and discussion.
+Fora archaeology from `~2017` and beyond.
 
 <div class="link-next">
   <a href="./add">New post</a>
@@ -30,7 +30,7 @@ Urbit Proposals (UPs) and discussion.
 
 <br />
 
-<div><list dataPath="./proposals/posts" dataPreview="true" dataType="post" sortBy="bump"></list></div>
+<div><list dataPath="./archive/posts" dataPreview="true" dataType="post" sortBy="bump"></list></div>
 
 <link rel="stylesheet" href="../main.css" />
 

--- a/fora/archive/add.md
+++ b/fora/archive/add.md
@@ -1,0 +1,12 @@
+---
+layout: forum
+anchor: none
+---
+
+# Add
+
+### [Back](../)
+
+<div><post src="../" /></div>
+
+<link rel="stylesheet" href="../../main.css" />

--- a/fora/general.md
+++ b/fora/general.md
@@ -19,6 +19,7 @@ If you're running an urbit, to post as your ship, [_Log In_](/~~/).
   <a class="subfora" href="../updates">Updates</a>
   <a class="subfora" href="../answers">Answers</a>
   <a class="subfora" href="../proposals">Proposals</a>
+  <a class="subfora" href="../archive">Archive</a>
 </nav>
 
 Long-form Urbit discussion.

--- a/fora/updates.md
+++ b/fora/updates.md
@@ -19,6 +19,7 @@ If you're running an urbit, to post as your ship, [_Log In_](/~~/).
   <b class="subfora active">Updates</b>
   <a class="subfora" href="../answers">Answers</a>
   <a class="subfora" href="../proposals">Proposals</a>
+  <a class="subfora" href="../archive">Archive</a>
 </nav>
 
 What's happening in the Urbit community.


### PR DESCRIPTION
This will shorten the build times of the main `general` section by only
including the posts of the current year, or any other filtering
mechanism we want. Don't get me wrong, though: this is a hack.